### PR TITLE
create .kube directory if it doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,14 @@ if (fs.existsSync(KUBE_CONFIG_PATH)) {
   }
 }
 
+if (!fs.existsSync(path.join(homedir, '.kube'))) {
+  try {
+    fs.mkdirSync(path.join(homedir, '.kube'))
+  } catch (err) {
+    fatal('Error creating a .kube folder in your home directory. You can try manually creating it.')
+  }
+}
+
 const kubesailContexts = config.contexts
   .map(
     context =>


### PR DESCRIPTION
Fixes issue[ #7](https://github.com/kubesail/deploy-node-app/issues/7) on [deploy-node-app.](https://github.com/kubesail/deploy-node-app) and also #1 

- Checks to see if the `homedir/.kube` directory exists 
- creates it if it doesn't.